### PR TITLE
`getToken` Can Return Either Access Token or Id Token

### DIFF
--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -492,12 +492,12 @@ public final class Auth {
         }
     }
     
-    /// Return the access token with auto-refresh mechanism.
-    /// - Returns: Returns access token, throw error if failed to refresh which may require re-authentication.
-    public func getToken() async throws -> String {
+    /// Return the desired token with auto-refresh mechanism.
+    /// - Returns: Returns either the access token (default) or the id token, throw error if failed to refresh which may require re-authentication.
+    public func getToken(desiredToken: TokenType = .accessToken) async throws -> String {
         do {
             if let tokens = try await performWithFreshTokens() {
-                return tokens.accessToken
+                return desiredToken == .accessToken ? tokens?.accessToken: tokens?.idToken
             }else {
                 throw AuthError.notAuthenticated
             }

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -497,7 +497,7 @@ public final class Auth {
     public func getToken(desiredToken: TokenType = .accessToken) async throws -> String {
         do {
             if let tokens = try await performWithFreshTokens() {
-                return desiredToken == .accessToken ? tokens?.accessToken: tokens?.idToken
+                return desiredToken == .accessToken ? tokens.accessToken: tokens.idToken
             }else {
                 throw AuthError.notAuthenticated
             }


### PR DESCRIPTION
The `getToken` method now accepts an argument allowing the caller to specify the token they want to retrieve. Returns access token by default to preserve existing behavior.

# Explain your changes
Fixed #21 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
