### PR TITLE
Base path issue fixed for custom domain

### DIFF
--- a/Sources/KindeSDK/APIs.swift
+++ b/Sources/KindeSDK/APIs.swift
@@ -118,7 +118,12 @@ public extension KindeSDKAPI {
             preconditionFailure("Failed to parse Business Name from configured issuer \(config.issuer)")
         }
         
-        basePath = basePath.replacingOccurrences(of: "://app.", with: "://\(businessName).")
+        // for full custom domain, the config.issuer will be as base path
+        if host.contains("kinde.com"){
+            basePath = basePath.replacingOccurrences(of: "://app.", with: "://\(businessName).")
+        }else{
+            basePath = config.issuer
+        }
         // Use Bearer authentication subclass of RequestBuilderFactory
         requestBuilderFactory = BearerRequestBuilderFactory()
         


### PR DESCRIPTION
# Summary
This PR fixes an issue related to the handling of custom domain formats in the KindeSDKAPI.configure method.
Details

# Issue: 
The previous implementation assumed that the basePath should always replace the subdomain app with the businessName extracted from the issuer URL. This caused issues when dealing with custom domains that do not follow the kinde.com format.

# Fix: 
The logic has been updated to account for custom domains:
        If the issuer contains "kinde.com", the basePath continues to replace ://app. with ://\(businessName). as before.
        If the issuer is a custom domain (i.e., it does not contain "kinde.com"), the basePath is now directly set to the issuer without any modifications.

```
 if host.contains("kinde.com"){
      basePath = basePath.replacingOccurrences(of: "://app.", with: "://\(businessName).")
 }else{
      basePath = config.issuer
 }
```

This fix ensures that custom domains are correctly handled without being incorrectly modified, preserving the correct base URL structure for API requests.

# Testing

    Verified that the basePath is correctly set for both standard kinde.com domains and custom domains.
    Confirmed that the Auth and Kinde Management APIs work as expected with the updated domain handling logic.