### PR TITLE
fixed missing email in token issue

### DIFF
--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -509,6 +509,18 @@ public final class Auth {
             throw AuthError.notAuthenticated
         }
     }
+    
+    public func getToken() async throws -> Tokens {
+        do {
+            if let tokens = try await performWithFreshTokens() {
+                return Tokens(accessToken: tokens.accessToken, idToken: tokens.idToken)
+            } else {
+                throw AuthError.notAuthenticated
+            }
+        } catch {
+            throw AuthError.notAuthenticated
+        }
+    }
 }
 
 // MARK: - Feature Flags

--- a/Sources/KindeSDK/Auth/Tokens.swift
+++ b/Sources/KindeSDK/Auth/Tokens.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Authentication and identity tokens from the Kinde service
 public struct Tokens {
     /// A bearer token for making authenticated calls to Kinde endpoints
-    var accessToken: String
+    public var accessToken: String
     /// An ID token for the subject of the `accessToken`
-    var idToken: String?
+    public var idToken: String?
 }
 
 public enum TokenType: String {

--- a/Sources/KindeSDK/Models/UserProfile.swift
+++ b/Sources/KindeSDK/Models/UserProfile.swift
@@ -16,14 +16,16 @@ public struct UserProfile: Codable, JSONEncodable, Hashable {
     public let givenName: String?
     public let familyName: String?
     public let updatedAt: Int
+    public let email: String?
 
-    public init(id: String, providedId: String? = nil, name: String? = nil, givenName: String? = nil, familyName: String? = nil, updatedAt: Int) {
+    public init(id: String, providedId: String? = nil, name: String? = nil, givenName: String? = nil, familyName: String? = nil, updatedAt: Int, email: String? = nil) {
         self.id = id
         self.providedId = providedId
         self.name = name
         self.givenName = givenName
         self.familyName = familyName
         self.updatedAt = updatedAt
+        self.email = email
     }
 
     public enum CodingKeys: String, CodingKey, CaseIterable {
@@ -33,6 +35,7 @@ public struct UserProfile: Codable, JSONEncodable, Hashable {
         case givenName = "given_name"
         case familyName = "family_name"
         case updatedAt = "updated_at"
+        case email
     }
 
     // Encodable protocol methods
@@ -45,6 +48,7 @@ public struct UserProfile: Codable, JSONEncodable, Hashable {
         try container.encodeIfPresent(givenName, forKey: .givenName)
         try container.encodeIfPresent(familyName, forKey: .familyName)
         try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(email, forKey: .email)
     }
 }
 


### PR DESCRIPTION
# Explain your changes

In the previous scenario, after signing in, to get the token, we use the function KindeSDKAPI.auth.getToken(). This function takes one parameter named desiredToken, which specifies the token we need. If we pass this parameter, the function returns the requested token. However, if the desiredToken parameter is not passed, the function returning the accessToken as default.

In the current scenario, I have now changed the implementation so that when the desiredToken parameter is not passed, both the (accessToken and idToken) will be returned in an object. If the desiredToken parameter is provided, the function will return only the token corresponding to the desiredToken as a  string.