### PR TITLE
Multiple configurations for development and production

### DIFF
--- a/Sources/KindeSDK/APIs.swift
+++ b/Sources/KindeSDK/APIs.swift
@@ -105,10 +105,13 @@ public extension KindeSDKAPI {
      `configure` must be called before `Auth` or any Kinde Management APIs are used.	
      	
      Set the host of the base URL of `OpenAPIClientAPI` to the business name extracted from the	
-     configured `issuer`. E.g., `https://example.kinde.com` -> `example`.	
-     */	
-    static func configure(_ logger: LoggerProtocol = DefaultLogger()) {
-        guard let config = Config.initialize() else {
+     configured `issuer`. E.g., `https://example.kinde.com` -> `example`.
+     
+     If your app requires multiple configurations for development and production, add all Kinde configuration files to your app target and specify the desired configuration using `configurationFileName`
+     
+     */
+    static func configure(_ logger: LoggerProtocol = DefaultLogger(), configurationFileName: String = "kinde-auth") {
+        guard let config = Config.initialize(configurationFileName: configurationFileName) else {
             preconditionFailure("Failed to load configuration")
         }
         
@@ -128,7 +131,7 @@ public extension KindeSDKAPI {
         requestBuilderFactory = BearerRequestBuilderFactory()
         
         auth = Auth(config: config,
-                    authStateRepository: AuthStateRepository(key: "\(Bundle.main.bundleIdentifier ?? "com.kinde.KindeAuth").authState", logger: logger),
+                    authStateRepository: AuthStateRepository(key: "\(Bundle.main.bundleIdentifier ?? "com.kinde.KindeAuth").\(config.clientId).authState", logger: logger),
                     logger: logger)
     }
 }

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -44,11 +44,14 @@ public struct Config: Decodable {
     }
     
     /// Load configuration from bundled source file: (default) `KindeAuth.plist` or `kinde-auth.json`
-    static func initialize() -> Config? {
+    /// If your app requires multiple configurations for development and production, add all Kinde configuration files to your app target and specify the desired configuration using `configurationFileName`
+    
+    static func initialize(configurationFileName: String = "kinde-auth") -> Config? {
         do {
+            let normalizedFileName = configurationFileName.replacingOccurrences(of: ".json", with: "")
             var configFilePath: String = ""
             for bundle in Bundle.allBundles {
-                if let resourcePath = bundle.path(forResource: "kinde-auth", ofType: "json") {
+                if let resourcePath = bundle.path(forResource: normalizedFileName, ofType: "json") {
                     configFilePath = resourcePath
                     break
                 }


### PR DESCRIPTION
# Dynamic Environment Switching in Kinde for iOS

This guide explains how to dynamically switch between **test** and **production** authentication environments in an iOS app using Kinde.


## Limitations  
Currently, Kinde does not provide a built-in mechanism to dynamically switch between environments (e.g., test and production) without manual intervention. This can be cumbersome for developers who need to test their apps in multiple environments.

---

## Solution  
To address this, the Kinde SDK introduces a new parameter called `configurationFileName`. This allows developers to specify different configuration files for each environment, enabling seamless switching between them.


### Implementation Steps  

1. **Add Configuration Files**  
   Include all required Kinde configuration files (e.g., `kinde-auth.json`, `kinde-auth-dev.json`) in your app target.  

2. **Initialize the SDK**  
   Use the `configurationFileName` parameter to specify the desired configuration file during SDK initialization.  


### Example Usage  

#### Default Initialization  
If your app uses the default configuration file (`kinde-auth.json`), initialize the SDK as follows:  
```swift  
KindeSDKAPI.configure(Logger())  
```

### Custom Initialization
To use a custom configuration file (e.g., kinde-auth-dev.json), pass the configurationFileName parameter:
```swift  
 KindeSDKAPI.configure(Logger(), configurationFileName: "kinde-auth-dev")
```

## Code Changes

### `APIs.swift`
- The `configure` method has been updated to include a `configurationFileName` parameter.

### `Config.swift`
- The `initialize` method has been updated to accept a `configurationFileName` parameter.  
- Automatically removes the `.json` extension if mistakenly provided.

### Authentication State Handling
- Since `AuthStateRepository` caches authentication state and tokens, dynamically switching configuration files may cause issues for logged-in users.  
- To resolve this, a unique key is now generated using `clientId` in `APIs.swift`.

### Updated Code
```swift
auth = Auth(
    config: config,
    authStateRepository: AuthStateRepository(
        key: "\(Bundle.main.bundleIdentifier ?? "com.kinde.KindeAuth").\(config.clientId).authState",
        logger: logger
    ),
    logger: logger
)
```

### Benefits
Flexibility: Easily switch between environments without modifying code.
Scalability: Add multiple configuration files for different environments (e.g., staging, QA).
Maintainability: Keep environment-specific settings isolated in separate files 

### Notes
- Ensure that all configuration files are added to the app target and are correctly named.
- The configurationFileName parameter should match the name of the JSON file (without the .json extension).

