### PR TITLE
added functionality for Multiple environments

### DIFF
--- a/Sources/KindeSDK/APIs.swift
+++ b/Sources/KindeSDK/APIs.swift
@@ -100,6 +100,16 @@ public protocol RequestBuilderFactory {
     func getBuilder<T: Decodable>() -> RequestBuilder<T>.Type
 }
 
+public func logout() {
+    guard let auth = KindeSDKAPI.auth else {
+        return
+    }
+
+    auth.logout { result in
+        print(result)
+    }
+}
+
 public extension KindeSDKAPI {	
     /**	
      `configure` must be called before `Auth` or any Kinde Management APIs are used.	
@@ -111,6 +121,8 @@ public extension KindeSDKAPI {
         guard let config = Config.initialize(fileName: fileName) else {
             preconditionFailure("Failed to load configuration")
         }
+        
+        let storedClientId = UserDefaults.standard.string(forKey: "clientId")
         
         guard let urlComponents = URLComponents(string: config.issuer),
            let host = urlComponents.host,
@@ -130,5 +142,13 @@ public extension KindeSDKAPI {
         auth = Auth(config: config,
                     authStateRepository: AuthStateRepository(key: "\(Bundle.main.bundleIdentifier ?? "com.kinde.KindeAuth").authState", logger: logger),
                     logger: logger)
+        
+        if storedClientId == nil {
+            logout()
+            UserDefaults.standard.set(config.clientId, forKey: "clientId")
+        } else if storedClientId != config.clientId {
+            logout()
+            UserDefaults.standard.set(config.clientId, forKey: "clientId")
+        }
     }
 }

--- a/Sources/KindeSDK/APIs.swift
+++ b/Sources/KindeSDK/APIs.swift
@@ -107,8 +107,8 @@ public extension KindeSDKAPI {
      Set the host of the base URL of `OpenAPIClientAPI` to the business name extracted from the	
      configured `issuer`. E.g., `https://example.kinde.com` -> `example`.	
      */	
-    static func configure(_ logger: LoggerProtocol = DefaultLogger()) {
-        guard let config = Config.initialize() else {
+    static func configure(_ logger: LoggerProtocol = DefaultLogger(), fileName: String = "kinde-auth") {
+        guard let config = Config.initialize(fileName: fileName) else {
             preconditionFailure("Failed to load configuration")
         }
         

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -44,11 +44,11 @@ public struct Config: Decodable {
     }
     
     /// Load configuration from bundled source file: (default) `KindeAuth.plist` or `kinde-auth.json`
-    static func initialize() -> Config? {
+    static func initialize(fileName: String) -> Config? {
         do {
             var configFilePath: String = ""
             for bundle in Bundle.allBundles {
-                if let resourcePath = bundle.path(forResource: "kinde-auth", ofType: "json") {
+                if let resourcePath = bundle.path(forResource: fileName, ofType: "json") {
                     configFilePath = resourcePath
                     break
                 }

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -47,8 +47,9 @@ public struct Config: Decodable {
     static func initialize(fileName: String) -> Config? {
         do {
             var configFilePath: String = ""
+            let cleanedFileName = fileName.replacingOccurrences(of: ".json", with: "")
             for bundle in Bundle.allBundles {
-                if let resourcePath = bundle.path(forResource: fileName, ofType: "json") {
+                if let resourcePath = bundle.path(forResource: cleanedFileName, ofType: "json") {
                     configFilePath = resourcePath
                     break
                 }


### PR DESCRIPTION
# Explain your changes

I have implemented functionality to support multiple environments. By passing a `fileName` parameter to the `KindeSDKAPI.configure` method, you can now test a specific environment. To do so, simply create a JSON file for that environment and pass its file name as the `fileName` parameter when calling the `KindeSDKAPI.configure` function. This will automatically initialize the appropriate environment.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
