### PR TITLE
Added planInterest and pricingTableKey parameters on registration

### DIFF
--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -142,11 +142,11 @@ public final class Auth {
     /// Register a new user
     ///
     @available(*, renamed: "register")
-    public func register(orgCode: String = "", loginHint: String = "",
+    public func register(orgCode: String = "", loginHint: String = "", planInterest: String = "",
                          _ completion: @escaping (Result<Bool, Error>) -> Void) {
         Task {
             do {
-                try await register(orgCode: orgCode, loginHint: loginHint)
+                try await register(orgCode: orgCode, loginHint: loginHint, planInterest: planInterest)
                 await MainActor.run(body: {
                     completion(.success(true))
                 })
@@ -158,7 +158,7 @@ public final class Auth {
         }
     }
     
-    public func register(orgCode: String = "", loginHint: String = "") async throws -> () {
+    public func register(orgCode: String = "", loginHint: String = "", planInterest: String = "") async throws -> () {
         return try await withCheckedThrowingContinuation { continuation in
             Task {
                 guard let viewController = await self.getViewController() else {
@@ -166,7 +166,7 @@ public final class Auth {
                     return
                 }
                 do {
-                    let request = try await self.getAuthorizationRequest(signUp: true, orgCode: orgCode, loginHint: loginHint)
+                    let request = try await self.getAuthorizationRequest(signUp: true, orgCode: orgCode, loginHint: loginHint, planInterest: planInterest)
                     _ = try await self.runCurrentAuthorizationFlow(request: request, viewController: viewController)
                     continuation.resume(with: .success(()))
                 } catch {
@@ -291,7 +291,8 @@ public final class Auth {
                                          loginHint: String = "",
                                          orgName: String = "",
                                          usePKCE: Bool = true,
-                                         useNonce: Bool = false) async throws -> OIDAuthorizationRequest {
+                                         useNonce: Bool = false,
+                                         planInterest: String = "") async throws -> OIDAuthorizationRequest {
         return try await withCheckedThrowingContinuation { continuation in
             Task {
                 let issuerUrl = config.getIssuerUrl()
@@ -308,7 +309,8 @@ public final class Auth {
                                                                  loginHint: loginHint,
                                                                  orgName: orgName,
                                                                  usePKCE: usePKCE,
-                                                                 useNonce: useNonce)
+                                                                 useNonce: useNonce,
+                                                                 planInterest: planInterest)
                     continuation.resume(returning: result)
                 } catch {
                     continuation.resume(throwing: error)
@@ -344,7 +346,8 @@ public final class Auth {
                                               loginHint: String = "",
                                               orgName: String = "",
                                               usePKCE: Bool = true,
-                                              useNonce: Bool = false) async throws -> (OIDAuthorizationRequest) {
+                                              useNonce: Bool = false,
+                                              planInterest: String = "") async throws -> (OIDAuthorizationRequest) {
         return try await withCheckedThrowingContinuation { continuation in
             OIDAuthorizationService.discoverConfiguration(forIssuer: issuerUrl) { configuration, error in
                 if let error = error {
@@ -391,6 +394,10 @@ public final class Auth {
                 if !loginHint.isEmpty {
                     additionalParameters["login_hint"] = loginHint
                 }
+                
+                if !planInterest.isEmpty {
+                    additionalParameters["plan_interest"] = planInterest
+                }
 
                 // if/when the API supports nonce validation
                 let codeChallengeMethod = usePKCE ? OIDOAuthorizationRequestCodeChallengeMethodS256 : nil
@@ -424,11 +431,10 @@ public final class Auth {
     
     func hasMatchingEmail(in authState: OIDAuthState) -> Bool {
         guard let currentIDToken = authState.lastTokenResponse?.idToken,
-              let existingIDToken = authStateRepository.state?.lastTokenResponse?.idToken,
+              let existingIDToken = self.authStateRepository.state?.lastTokenResponse?.idToken,
               let currentEmail = extractEmail(from: currentIDToken),
               let existingEmail = extractEmail(from: existingIDToken)
         else { return false }
-
         return currentEmail == existingEmail
     }
 


### PR DESCRIPTION
# Explain your changes

This PR introduces a new parameter to the `plan_interest` string in the user registration flow.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
