### PR TITLE
fix: auth callback not being called

### DIFF
--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -473,10 +473,9 @@ public final class Auth {
                     let timeout = self.config.authorizationFlowTimeout ?? Self.defaultAuthorizationFlowTimeout
                     let timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
                         self.logger.error(message: "Authorization flow timed out after \(timeout) seconds")
-                        _ = self.authStateRepository.clear()
-                        resumeOnce(.failure(AuthError.timeout))
                         self.currentAuthorizationFlow?.cancel()
                         self.currentAuthorizationFlow = nil
+                        resumeOnce(.failure(AuthError.timeout))
                     }
                     currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
                                                                       presenting: viewController,

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -446,11 +446,16 @@ public final class Auth {
 
     private func runCurrentAuthorizationFlow(request: OIDAuthorizationRequest, viewController: UIViewController) async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in
+            let resumeLock = NSLock()
             var hasResumed = false
 
             func resumeOnce(_ result: Result<Bool, Error>) {
+                resumeLock.lock()
+                defer { resumeLock.unlock() }
+                
                 guard !hasResumed else { return }
                 hasResumed = true
+                
                 switch result {
                 case .success(let value):
                     continuation.resume(returning: value)

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -461,7 +461,9 @@ public final class Auth {
 
             Task {
                 await MainActor.run {
+                    currentAuthorizationFlow?.cancel()
                     let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
+                        self.currentAuthorizationFlow = nil
                         resumeOnce(.failure(AuthError.timeout))
                     }
                     currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
@@ -598,6 +600,7 @@ public final class Auth {
     /// Callback to complete the current authorization flow
     private func authorizationFlowCallback(then completion: @escaping (Result<Bool, Error>) -> Void) -> (OIDAuthState?, Error?) -> Void {
         return { authState, error in
+            self.currentAuthorizationFlow = nil
             if let error = error {
                 self.logger.error(message: "Failed to finish authentication flow: \(error.localizedDescription)")
                 _ = self.authStateRepository.clear()
@@ -617,7 +620,6 @@ public final class Auth {
                 return completion(.failure(AuthError.failedToSaveState))
             }
             
-            self.currentAuthorizationFlow = nil
             completion(.success(true))
         }
     }

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -442,7 +442,6 @@ public final class Auth {
     }
     
     #if canImport(UIKit)
-    private static let defaultAuthorizationFlowTimeout: TimeInterval = 120
 
     private func runCurrentAuthorizationFlow(request: OIDAuthorizationRequest, viewController: UIViewController) async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in
@@ -470,7 +469,7 @@ public final class Auth {
                         resumeOnce(.failure(AuthError.authFlowAlreadyInProgress))
                         return
                     }
-                    let timeout = self.config.authorizationFlowTimeout ?? Self.defaultAuthorizationFlowTimeout
+                    let timeout = self.config.getAuthorizationFlowTimeout()
                     let timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
                         self.logger.error(message: "Authorization flow timed out after \(timeout) seconds")
                         self.currentAuthorizationFlow?.cancel()

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -442,7 +442,7 @@ public final class Auth {
     }
     
     #if canImport(UIKit)
-    private static let authorizationFlowTimeout: TimeInterval = 120
+    private static let defaultAuthorizationFlowTimeout: TimeInterval = 120
 
     private func runCurrentAuthorizationFlow(request: OIDAuthorizationRequest, viewController: UIViewController) async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in
@@ -465,8 +465,9 @@ public final class Auth {
                         resumeOnce(.failure(AuthError.authFlowAlreadyInProgress))
                         return
                     }
-                    let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
-                        self.logger.error(message: "Authorization flow timed out after \(Self.authorizationFlowTimeout) seconds")
+                    let timeout = self.config.authorizationFlowTimeout ?? Self.defaultAuthorizationFlowTimeout
+                    let timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
+                        self.logger.error(message: "Authorization flow timed out after \(timeout) seconds")
                         _ = self.authStateRepository.clear()
                         resumeOnce(.failure(AuthError.timeout))
                         self.currentAuthorizationFlow?.cancel()

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -8,7 +8,7 @@ import UIKit
 @available(iOS 13.0, *)
 public final class Auth {
     @Atomic private var currentAuthorizationFlow: OIDExternalUserAgentSession?
-    
+
     private let config: Config
     private let authStateRepository: AuthStateRepository
     private let logger: LoggerProtocol
@@ -461,7 +461,10 @@ public final class Auth {
 
             Task {
                 await MainActor.run {
-                    currentAuthorizationFlow?.cancel()
+                    if currentAuthorizationFlow != nil {
+                        resumeOnce(.failure(AuthError.authFlowAlreadyInProgress))
+                        return
+                    }
                     let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
                         self.logger.error(message: "Authorization flow timed out after \(Self.authorizationFlowTimeout) seconds")
                         _ = self.authStateRepository.clear()
@@ -631,6 +634,14 @@ public final class Auth {
     public func isUserCancellationErrorCode(_ error: Error) -> Bool {
         let error = error as NSError
         return error.domain == OIDGeneralErrorDomain && error.code == OIDErrorCode.userCanceledAuthorizationFlow.rawValue
+    }
+
+    /// Is the given error because an auth flow was already in progress (e.g. double-tap ignored)
+    public func isAuthFlowAlreadyInProgressError(_ error: Error) -> Bool {
+        if case AuthError.authFlowAlreadyInProgress = error {
+            return true
+        }
+        return false
     }
     
     /// Perform an action, such as an API call, with a valid access token and ID token

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -476,18 +476,22 @@ public final class Auth {
                         self.currentAuthorizationFlow = nil
                         resumeOnce(.failure(AuthError.timeout))
                     }
-                    currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
-                                                                      presenting: viewController,
-                                                                      prefersEphemeralSession: privateAuthSession,
-                                                                      callback: authorizationFlowCallback(then: { value in
-                        timer.invalidate()
+                    let flowCallback = authorizationFlowCallback(then: { value in
                         switch value {
                         case .success:
                             resumeOnce(.success(true))
                         case .failure(let error):
                             resumeOnce(.failure(error))
                         }
-                    }))
+                    })
+
+                    currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
+                                                                      presenting: viewController,
+                                                                      prefersEphemeralSession: privateAuthSession,
+                                                                      callback: { authState, error in
+                        timer.invalidate()
+                        flowCallback(authState, error)
+                    })
                 }
             }
         }

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -617,7 +617,9 @@ public final class Auth {
             self.currentAuthorizationFlow = nil
             if let error = error {
                 self.logger.error(message: "Failed to finish authentication flow: \(error.localizedDescription)")
-                _ = self.authStateRepository.clear()
+                if !self.isAuthorizationFlowCancellationError(error) {
+                    _ = self.authStateRepository.clear()
+                }
                 return completion(.failure(error))
             }
             
@@ -636,6 +638,17 @@ public final class Auth {
             
             completion(.success(true))
         }
+    }
+
+    /// Is the given error the result of cancellation (user or program) of an authorization flow
+    private func isAuthorizationFlowCancellationError(_ error: Error) -> Bool {
+        let error = error as NSError
+        guard error.domain == OIDGeneralErrorDomain else { return false }
+        
+        let errorCode = error.code
+        
+        return errorCode == OIDErrorCode.userCanceledAuthorizationFlow.rawValue
+        || errorCode == OIDErrorCode.programCanceledAuthorizationFlow.rawValue
     }
     
     /// Is the given error the result of user cancellation of an authorization flow

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -442,7 +442,7 @@ public final class Auth {
     }
     
     #if canImport(UIKit)
-    private static let authorizationFlowTimeout: TimeInterval = 60
+    private static let authorizationFlowTimeout: TimeInterval = 120
 
     private func runCurrentAuthorizationFlow(request: OIDAuthorizationRequest, viewController: UIViewController) async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -463,8 +463,9 @@ public final class Auth {
                 await MainActor.run {
                     currentAuthorizationFlow?.cancel()
                     let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
-                        self.currentAuthorizationFlow = nil
                         resumeOnce(.failure(AuthError.timeout))
+                        self.currentAuthorizationFlow?.cancel()
+                        self.currentAuthorizationFlow = nil
                     }
                     currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
                                                                       presenting: viewController,

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -463,6 +463,8 @@ public final class Auth {
                 await MainActor.run {
                     currentAuthorizationFlow?.cancel()
                     let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
+                        self.logger.error(message: "Authorization flow timed out after \(Self.authorizationFlowTimeout) seconds")
+                        _ = self.authStateRepository.clear()
                         resumeOnce(.failure(AuthError.timeout))
                         self.currentAuthorizationFlow?.cancel()
                         self.currentAuthorizationFlow = nil

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -442,19 +442,38 @@ public final class Auth {
     }
     
     #if canImport(UIKit)
+    private static let authorizationFlowTimeout: TimeInterval = 60
+
     private func runCurrentAuthorizationFlow(request: OIDAuthorizationRequest, viewController: UIViewController) async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in
+            var hasResumed = false
+
+            func resumeOnce(_ result: Result<Bool, Error>) {
+                guard !hasResumed else { return }
+                hasResumed = true
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
             Task {
                 await MainActor.run {
+                    let timer = Timer.scheduledTimer(withTimeInterval: Self.authorizationFlowTimeout, repeats: false) { _ in
+                        resumeOnce(.failure(AuthError.timeout))
+                    }
                     currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
                                                                       presenting: viewController,
                                                                       prefersEphemeralSession: privateAuthSession,
                                                                       callback: authorizationFlowCallback(then: { value in
+                        timer.invalidate()
                         switch value {
                         case .success:
-                            continuation.resume(returning: true)
+                            resumeOnce(.success(true))
                         case .failure(let error):
-                            continuation.resume(throwing: error)
+                            resumeOnce(.failure(error))
                         }
                     }))
                 }

--- a/Sources/KindeSDK/Auth/Auth.swift
+++ b/Sources/KindeSDK/Auth/Auth.swift
@@ -636,6 +636,14 @@ public final class Auth {
         return error.domain == OIDGeneralErrorDomain && error.code == OIDErrorCode.userCanceledAuthorizationFlow.rawValue
     }
 
+    /// Is the given error because an auth flow timed out
+    public func isAuthFlowTimeoutError(_ error: Error) -> Bool {
+        if case AuthError.timeout = error {
+            return true
+        }
+        return false
+    }
+
     /// Is the given error because an auth flow was already in progress (e.g. double-tap ignored)
     public func isAuthFlowAlreadyInProgressError(_ error: Error) -> Bool {
         if case AuthError.authFlowAlreadyInProgress = error {

--- a/Sources/KindeSDK/Auth/AuthError.swift
+++ b/Sources/KindeSDK/Auth/AuthError.swift
@@ -17,6 +17,8 @@ public enum AuthError: Error {
     case decodingError
     /// Authorization flow timed out
     case timeout
+    /// An authorization flow is already in progress
+    case authFlowAlreadyInProgress
 }
 
 extension AuthError: LocalizedError {
@@ -61,6 +63,11 @@ extension AuthError: LocalizedError {
             return NSLocalizedString(
                 "Authorization flow timed out.",
                 comment: "Timeout"
+            )
+        case .authFlowAlreadyInProgress:
+            return NSLocalizedString(
+                "An authorization flow is already in progress.",
+                comment: "Auth flow already in progress"
             )
         }
     }

--- a/Sources/KindeSDK/Auth/AuthError.swift
+++ b/Sources/KindeSDK/Auth/AuthError.swift
@@ -15,6 +15,8 @@ public enum AuthError: Error {
     case serverError(Int)
     /// Failed to decode response data
     case decodingError
+    /// Authorization flow timed out
+    case timeout
 }
 
 extension AuthError: LocalizedError {
@@ -54,6 +56,11 @@ extension AuthError: LocalizedError {
             return NSLocalizedString(
                 "Failed to decode response data.",
                 comment: "Decoding Error"
+            )
+        case .timeout:
+            return NSLocalizedString(
+                "Authorization flow timed out.",
+                comment: "Timeout"
             )
         }
     }

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -8,15 +8,18 @@ public struct Config: Decodable {
     let postLogoutRedirectUri: String
     let scope: String
     let audience: String?
+    let authorizationFlowTimeout: TimeInterval?
     
     public init(issuer: String, clientId: String, redirectUri: String,
-                postLogoutRedirectUri: String, scope: String, audience: String?) {
+                postLogoutRedirectUri: String, scope: String, audience: String?,
+                authorizationFlowTimeout: TimeInterval? = nil) {
         self.issuer = issuer
         self.clientId = clientId
         self.redirectUri = redirectUri
         self.postLogoutRedirectUri = postLogoutRedirectUri
         self.scope = scope
         self.audience = audience
+        self.authorizationFlowTimeout = authorizationFlowTimeout
     }
     
     /// Get the configured Issuer URL, or `nil` if it is missing or malformed
@@ -89,11 +92,13 @@ public struct Config: Decodable {
                 return nil
             }
         let audience = values["Audience"] as? String
+        let timeout = values["AuthorizationFlowTimeout"] as? TimeInterval
         return Config(issuer: issuer,
                       clientId: clientId,
                       redirectUri: redirectUri,
                       postLogoutRedirectUri: postLogoutRedirectUri,
                       scope: scope,
-                      audience: audience)
+                      audience: audience,
+                      authorizationFlowTimeout: timeout)
     }
 }

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -21,6 +21,12 @@ public struct Config: Decodable {
         self.audience = audience
         self.authorizationFlowTimeout = authorizationFlowTimeout
     }
+
+    private static let defaultAuthorizationFlowTimeout: TimeInterval = 120
+
+    public func getAuthorizationFlowTimeout() -> TimeInterval {
+        return self.authorizationFlowTimeout ?? Self.defaultAuthorizationFlowTimeout
+    }
     
     /// Get the configured Issuer URL, or `nil` if it is missing or malformed
     public func getIssuerUrl() -> URL? {

--- a/Sources/KindeSDK/Auth/Config.swift
+++ b/Sources/KindeSDK/Auth/Config.swift
@@ -25,7 +25,12 @@ public struct Config: Decodable {
     private static let defaultAuthorizationFlowTimeout: TimeInterval = 120
 
     public func getAuthorizationFlowTimeout() -> TimeInterval {
-        return self.authorizationFlowTimeout ?? Self.defaultAuthorizationFlowTimeout
+        guard let timeout = self.authorizationFlowTimeout, 
+              timeout.isFinite, 
+              timeout > 0 else {
+            return Self.defaultAuthorizationFlowTimeout
+        }
+        return timeout
     }
     
     /// Get the configured Issuer URL, or `nil` if it is missing or malformed


### PR DESCRIPTION
# Explain your changes

This PR updates the SDK with the following changes:
- adds a timeout (2 minutes currently) which throws `AuthError.timeout` on timed out auth requests 
- processes a single request at a time by throwing `AuthError.authFlowAlreadyInProgress` on concurrent requests (e.g accidental double taps)

## Screen recordings: 
- Double tap no longer causing an error:
   

   https://github.com/user-attachments/assets/93721558-efe8-49bb-93e1-be663b3d992a



- Timeout triggered 
   
   https://github.com/user-attachments/assets/c9c4d0c4-49d2-46bf-b101-8d886f15ce9c




# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
